### PR TITLE
Bugfixes

### DIFF
--- a/decode.c
+++ b/decode.c
@@ -1270,6 +1270,7 @@ static int DumpCompressedString(const char *data, int32 compressed_size, int (*p
 #else
 			printf("Error: compression method lz4 not supported.\n");
 			printf("Try to rebuild pg_filedump for PostgreSQL server of version 14+ with --with-lz4 option.\n");
+			free(decompress_tmp_buff);
 			return -2;
 #endif
 		default:

--- a/decode.c
+++ b/decode.c
@@ -1351,8 +1351,7 @@ ReadStringFromToast(const char *buffer,
 					toast_relation_filename);
 			result = -1;
 		}
-
-		if (result == 0)
+		else
 		{
 			unsigned int toast_relation_block_size = GetBlockSize(toast_rel_fp);
 			fseek(toast_rel_fp, 0, SEEK_SET);
@@ -1382,9 +1381,9 @@ ReadStringFromToast(const char *buffer,
 			}
 
 			free(toast_data);
+			fclose(toast_rel_fp);
 		}
 
-		fclose(toast_rel_fp);
 		free(toast_relation_path);
 	}
 	/* If tag is indirect or expanded, it was stored in memory. */


### PR DESCRIPTION
Fixing the following bugs:
1. Dynamically allocated decompress_tmp_buff is not freed when returning function on error.
2. fclose(toast_rel_fp) might be called when toast_rel_fp is NULL, which is an undefined behavior.