### PR TITLE
Fix incorrect oid

### DIFF
--- a/decode.c
+++ b/decode.c
@@ -697,7 +697,7 @@ decode_int(const char *buffer, unsigned int buff_size, unsigned int *out_size)
 	if (buff_size < sizeof(int32))
 		return -2;
 
-	CopyAppendFmt("%d", *(int32 *) buffer);
+	CopyAppendFmt("%u", *(uint32 *) buffer);
 	*out_size = sizeof(int32) + delta;
 	return 0;
 }


### PR DESCRIPTION
oid greater than 2147483647 is shown incorrectly. It happens because the function decode_int() calls CopyAppendFmt("%d", *(int32 *) buffer), it should be CopyAppendFmt("%u", *(uint32 *) buffer).

This is related to https://github.com/df7cb/pg_filedump/issues/18