### PR TITLE
Fixed bug with number of digits for numeric being calculated wrong.

### DIFF
--- a/decode.c
+++ b/decode.c
@@ -430,7 +430,7 @@ CopyAppendNumeric(const char *buffer, int num_size)
 		}
 		else
 		{
-			ndigits = num_size / sizeof(NumericDigit);
+			ndigits = (num_size - NUMERIC_HEADER_SIZE(num)) / sizeof(NumericDigit);
 			digits = (NumericDigit *) ((char *) num + NUMERIC_HEADER_SIZE(num));
 			i = (weight + 1) * DEC_DIGITS;
 			if (i <= 0)


### PR DESCRIPTION
In calculating number of digits to parse for numeric, whole size of struct numeric data was used. It It led to outputing junk data. Added subtraction of numeric header size, which removed reading wrong data. Partially resolves #31 