### PR TITLE
Fix masking changing values in tests

### DIFF
--- a/expected/datatypes.out
+++ b/expected/datatypes.out
@@ -14,7 +14,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -48,7 +48,7 @@ COPY: 4	four
 ----------------------------------------------------------------------------------------------
 --
 -- do one test without options
-\! pg_filedump int,text.heap | sed -e 's/logid      ./logid      ./' -e 's/recoff 0x......../recoff 0x......../'
+\! pg_filedump int,text.heap | sed -e 's/logid      ./logid      ./' -e 's/recoff 0x......../recoff 0x......../' -e 's/Checksum: 0x..../Checksum: 0x0000/'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -88,7 +88,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -134,7 +134,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -178,7 +178,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -220,7 +220,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -264,7 +264,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -316,7 +316,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -362,7 +362,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -410,7 +410,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -452,7 +452,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -496,7 +496,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -542,7 +542,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -588,7 +588,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -630,7 +630,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -676,7 +676,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -725,7 +725,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -773,7 +773,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -821,7 +821,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -865,7 +865,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -909,7 +909,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -953,7 +953,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/datatypes_3.out
+++ b/expected/datatypes_3.out
@@ -14,7 +14,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -48,7 +48,7 @@ COPY: 4	four
 ----------------------------------------------------------------------------------------------
 --
 -- do one test without options
-\! pg_filedump int,text.heap | sed -e 's/logid      ./logid      ./' -e 's/recoff 0x......../recoff 0x......../'
+\! pg_filedump int,text.heap | sed -e 's/logid      ./logid      ./' -e 's/recoff 0x......../recoff 0x......../' -e 's/Checksum: 0x..../Checksum: 0x0000/'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -88,7 +88,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -134,7 +134,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -178,7 +178,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -220,7 +220,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -264,7 +264,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -316,7 +316,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -362,7 +362,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -410,7 +410,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -452,7 +452,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -496,7 +496,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -542,7 +542,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -588,7 +588,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -630,7 +630,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -676,7 +676,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -725,7 +725,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -773,7 +773,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -821,7 +821,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -865,7 +865,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -909,7 +909,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -953,7 +953,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/float.out
+++ b/expected/float.out
@@ -15,7 +15,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -65,7 +65,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/float_1.out
+++ b/expected/float_1.out
@@ -15,7 +15,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -65,7 +65,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/float_3.out
+++ b/expected/float_3.out
@@ -15,7 +15,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -65,7 +65,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/float_4.out
+++ b/expected/float_4.out
@@ -15,7 +15,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -65,7 +65,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/numeric.out
+++ b/expected/numeric.out
@@ -16,7 +16,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/numeric_1.out
+++ b/expected/numeric_1.out
@@ -19,7 +19,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/numeric_3.out
+++ b/expected/numeric_3.out
@@ -16,7 +16,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/numeric_4.out
+++ b/expected/numeric_4.out
@@ -19,7 +19,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/toast.out
+++ b/expected/toast.out
@@ -62,7 +62,7 @@ COPY: extended compressed lz4	(TOASTED,lz4)
 
 
 *** End of File Encountered. Last Block Read: 0 ***
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id: \+[0-9]\+,/id:  .....,/g' -e 's/ 8< .*//'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/toast.out
+++ b/expected/toast.out
@@ -26,7 +26,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'reltoastrelid')) as toast_loi
 \set output :reltoastrelid
 \lo_export :toast_loid :output
 \setenv relname :relname
-\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/Checksum: 0x..../Checksum: 0x0000/'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -62,7 +62,7 @@ COPY: extended compressed lz4	(TOASTED,lz4)
 
 
 *** End of File Encountered. Last Block Read: 0 ***
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id: \+[0-9]\+,/id:  .....,/g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/Checksum: 0x..../Checksum: 0x0000/' -e 's/id: \+[0-9]\+,/id:  .....,/g' -e 's/ 8< .*//'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/toast_1.out
+++ b/expected/toast_1.out
@@ -29,7 +29,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'reltoastrelid')) as toast_loi
 \set output :reltoastrelid
 \lo_export :toast_loid :output
 \setenv relname :relname
-\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/Checksum: 0x..../Checksum: 0x0000/'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -65,7 +65,7 @@ COPY: extended compressed lz4	(TOASTED,pglz)
 
 
 *** End of File Encountered. Last Block Read: 0 ***
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id: \+[0-9]\+,/id:  .....,/g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/Checksum: 0x..../Checksum: 0x0000/' -e 's/id: \+[0-9]\+,/id:  .....,/g' -e 's/ 8< .*//'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/toast_1.out
+++ b/expected/toast_1.out
@@ -65,7 +65,7 @@ COPY: extended compressed lz4	(TOASTED,pglz)
 
 
 *** End of File Encountered. Last Block Read: 0 ***
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id: \+[0-9]\+,/id:  .....,/g' -e 's/ 8< .*//'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/toast_3.out
+++ b/expected/toast_3.out
@@ -62,7 +62,7 @@ COPY: extended compressed lz4	(TOASTED,lz4)
 
 
 *** End of File Encountered. Last Block Read: 0 ***
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id: \+[0-9]\+,/id:  .....,/g' -e 's/ 8< .*//'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/toast_3.out
+++ b/expected/toast_3.out
@@ -26,7 +26,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'reltoastrelid')) as toast_loi
 \set output :reltoastrelid
 \lo_export :toast_loid :output
 \setenv relname :relname
-\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/Checksum: 0x..../Checksum: 0x0000/'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -62,7 +62,7 @@ COPY: extended compressed lz4	(TOASTED,lz4)
 
 
 *** End of File Encountered. Last Block Read: 0 ***
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id: \+[0-9]\+,/id:  .....,/g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/Checksum: 0x..../Checksum: 0x0000/' -e 's/id: \+[0-9]\+,/id:  .....,/g' -e 's/ 8< .*//'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/toast_4.out
+++ b/expected/toast_4.out
@@ -29,7 +29,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'reltoastrelid')) as toast_loi
 \set output :reltoastrelid
 \lo_export :toast_loid :output
 \setenv relname :relname
-\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/Checksum: 0x..../Checksum: 0x0000/'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -65,7 +65,7 @@ COPY: extended compressed lz4	(TOASTED,pglz)
 
 
 *** End of File Encountered. Last Block Read: 0 ***
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id: \+[0-9]\+,/id:  .....,/g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/Checksum: 0x..../Checksum: 0x0000/' -e 's/id: \+[0-9]\+,/id:  .....,/g' -e 's/ 8< .*//'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/toast_4.out
+++ b/expected/toast_4.out
@@ -65,7 +65,7 @@ COPY: extended compressed lz4	(TOASTED,pglz)
 
 
 *** End of File Encountered. Last Block Read: 0 ***
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id: \+[0-9]\+,/id:  .....,/g' -e 's/ 8< .*//'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/xml.out
+++ b/expected/xml.out
@@ -15,7 +15,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/xml_1.out
+++ b/expected/xml_1.out
@@ -20,7 +20,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/xml_3.out
+++ b/expected/xml_3.out
@@ -15,7 +15,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/run_test.sql
+++ b/run_test.sql
@@ -9,7 +9,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \lo_export :oid :output
 
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e "s/Checksum: 0x..../Checksum: 0x0000/"
 
 --
 ----------------------------------------------------------------------------------------------

--- a/sql/datatypes.sql
+++ b/sql/datatypes.sql
@@ -10,7 +10,7 @@ insert into "int,text" values (1, 'one'), (null, 'two'), (3, null), (4, 'four');
 \ir run_test.sql
 
 -- do one test without options
-\! pg_filedump int,text.heap | sed -e 's/logid      ./logid      ./' -e 's/recoff 0x......../recoff 0x......../'
+\! pg_filedump int,text.heap | sed -e 's/logid      ./logid      ./' -e 's/recoff 0x......../recoff 0x......../' -e 's/Checksum: 0x..../Checksum: 0x0000/'
 
 ----------------------------------------------------------------------------------------------
 

--- a/sql/toast.sql
+++ b/sql/toast.sql
@@ -34,5 +34,5 @@ select lo_import(format('base/%s/%s', :'datoid', :'reltoastrelid')) as toast_loi
 \lo_export :toast_loid :output
 
 \setenv relname :relname
-\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id: \+[0-9]\+,/id:  .....,/g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/Checksum: 0x..../Checksum: 0x0000/'
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/Checksum: 0x..../Checksum: 0x0000/' -e 's/id: \+[0-9]\+,/id:  .....,/g' -e 's/ 8< .*//'

--- a/sql/toast.sql
+++ b/sql/toast.sql
@@ -35,4 +35,4 @@ select lo_import(format('base/%s/%s', :'datoid', :'reltoastrelid')) as toast_loi
 
 \setenv relname :relname
 \! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id: \+[0-9]\+,/id:  .....,/g' -e 's/ 8< .*//'


### PR DESCRIPTION
After running make installcheck for postgres a few times, make installcheck for pg_filedump fails:
```
@@ -86,17 +86,17 @@
  Item   2 -- Length:  256  Offset: 7888 (0x1ed0)  Flags: NORMAL
 COPY: long inline uncompressed	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
  Item   3 -- Length:   64  Offset: 7824 (0x1e90)  Flags: NORMAL
-  TOAST value. Raw size:     2804, external size:     2800, value id:  ....., toast relation id:  ....., chunks:      2
+  TOAST value. Raw size:     2804, external size:     2800, value id: 106494, toast relation id: 106492, chunks:      2
 COPY: external uncompressed	0123456789
  Item   4 -- Length:  107  Offset: 7712 (0x1e20)  Flags: NORMAL
 COPY: inline compressed pglz	0123456789
  Item   5 -- Length:   67  Offset: 7640 (0x1dd8)  Flags: NORMAL
-  TOAST value. Raw size:   280004, external size:     3226, value id:  ....., toast relation id:  ....., chunks:      2
+  TOAST value. Raw size:   280004, external size:     3226, value id: 106495, toast relation id: 106492, chunks:      2
 COPY: extended compressed pglz	0123456789
  Item   6 -- Length:   90  Offset: 7544 (0x1d78)  Flags: NORMAL
 COPY: inline compressed lz4	0123456789
  Item   7 -- Length:   66  Offset: 7472 (0x1d30)  Flags: NORMAL
-  TOAST value. Raw size:   700004, external size:     2772, value id:  ....., toast relation id:  ....., chunks:      2
+  TOAST value. Raw size:   700004, external size:     2772, value id: 106496, toast relation id: 106492, chunks:      2
 COPY: extended compressed lz4	0123456789
```
This is caused by masking in tests considering the va_valueid, va_toasterlid (Oid) to be five digits long, which is not always true. 
Also with checksums now on by default make installcheck for pg_filedump on REL_18 fails too.