### PR TITLE
Data block details were lost for GIN index

### DIFF
--- a/expected/datatypes.out
+++ b/expected/datatypes.out
@@ -14,7 +14,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -48,7 +48,7 @@ COPY: 4	four
 ----------------------------------------------------------------------------------------------
 --
 -- do one test without options
-\! pg_filedump int,text.heap | sed -e 's/logid      ./logid      ./' -e 's/recoff 0x......../recoff 0x......../'
+\! pg_filedump int,text.heap | sed -e 's/logid      ./logid      ./' -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -88,7 +88,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -134,7 +134,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -178,7 +178,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -220,7 +220,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -264,7 +264,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -316,7 +316,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -362,7 +362,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -410,7 +410,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -452,7 +452,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -496,7 +496,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -542,7 +542,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -588,7 +588,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -630,7 +630,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -676,7 +676,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -725,7 +725,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -773,7 +773,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -821,7 +821,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -865,7 +865,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -909,7 +909,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -953,7 +953,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/datatypes_3.out
+++ b/expected/datatypes_3.out
@@ -14,7 +14,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -48,7 +48,7 @@ COPY: 4	four
 ----------------------------------------------------------------------------------------------
 --
 -- do one test without options
-\! pg_filedump int,text.heap | sed -e 's/logid      ./logid      ./' -e 's/recoff 0x......../recoff 0x......../'
+\! pg_filedump int,text.heap | sed -e 's/logid      ./logid      ./' -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -88,7 +88,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -134,7 +134,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -178,7 +178,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -220,7 +220,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -264,7 +264,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -316,7 +316,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -362,7 +362,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -410,7 +410,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -452,7 +452,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -496,7 +496,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -542,7 +542,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -588,7 +588,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -630,7 +630,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -676,7 +676,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -725,7 +725,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -773,7 +773,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -821,7 +821,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -865,7 +865,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -909,7 +909,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -953,7 +953,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/float.out
+++ b/expected/float.out
@@ -15,7 +15,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -65,7 +65,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/float_1.out
+++ b/expected/float_1.out
@@ -15,7 +15,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -65,7 +65,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/float_3.out
+++ b/expected/float_3.out
@@ -15,7 +15,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -65,7 +65,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/float_4.out
+++ b/expected/float_4.out
@@ -15,7 +15,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -65,7 +65,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/numeric.out
+++ b/expected/numeric.out
@@ -16,7 +16,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/numeric_1.out
+++ b/expected/numeric_1.out
@@ -19,7 +19,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/numeric_3.out
+++ b/expected/numeric_3.out
@@ -16,7 +16,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/numeric_4.out
+++ b/expected/numeric_4.out
@@ -19,7 +19,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/toast.out
+++ b/expected/toast.out
@@ -26,7 +26,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'reltoastrelid')) as toast_loi
 \set output :reltoastrelid
 \lo_export :toast_loid :output
 \setenv relname :relname
-\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -62,7 +62,7 @@ COPY: extended compressed lz4	(TOASTED,lz4)
 
 
 *** End of File Encountered. Last Block Read: 0 ***
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/toast_1.out
+++ b/expected/toast_1.out
@@ -29,7 +29,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'reltoastrelid')) as toast_loi
 \set output :reltoastrelid
 \lo_export :toast_loid :output
 \setenv relname :relname
-\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -65,7 +65,7 @@ COPY: extended compressed lz4	(TOASTED,pglz)
 
 
 *** End of File Encountered. Last Block Read: 0 ***
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/toast_3.out
+++ b/expected/toast_3.out
@@ -26,7 +26,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'reltoastrelid')) as toast_loi
 \set output :reltoastrelid
 \lo_export :toast_loid :output
 \setenv relname :relname
-\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -62,7 +62,7 @@ COPY: extended compressed lz4	(TOASTED,lz4)
 
 
 *** End of File Encountered. Last Block Read: 0 ***
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/toast_4.out
+++ b/expected/toast_4.out
@@ -29,7 +29,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'reltoastrelid')) as toast_loi
 \set output :reltoastrelid
 \lo_export :toast_loid :output
 \setenv relname :relname
-\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -65,7 +65,7 @@ COPY: extended compressed lz4	(TOASTED,pglz)
 
 
 *** End of File Encountered. Last Block Read: 0 ***
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/xml.out
+++ b/expected/xml.out
@@ -15,7 +15,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/xml_1.out
+++ b/expected/xml_1.out
@@ -20,7 +20,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/xml_3.out
+++ b/expected/xml_3.out
@@ -15,7 +15,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/pg_filedump.c
+++ b/pg_filedump.c
@@ -149,6 +149,13 @@ static void FormatBinary(char *buffer,
 		unsigned int numBytes, unsigned int startIndex);
 static void DumpBinaryBlock(char *buffer);
 static int PrintRelMappings(void);
+static ItemPointer ginPostingListDecodeAllSegmentsItems(
+		GinPostingList *segment,
+		int len,
+		int *ndecoded_out);
+static ItemPointer ginReadTupleItems(
+		IndexTuple itup,
+		int *nitems);
 
 
 /* Send properly formed usage information to the user. */
@@ -825,22 +832,6 @@ IsGinMetaPage(Page page)
 	return false;
 }
 
-/*	Check whether page is a gin leaf page */
-static bool
-IsGinLeafPage(Page page)
-{
-	if ((PageGetSpecialSize(page) == (MAXALIGN(sizeof(GinPageOpaqueData))))
-		&& (bytesToFormat == blockSize))
-	{
-		GinPageOpaque gpo = GinPageGetOpaque(page);
-
-		if (gpo->flags & GIN_LEAF)
-			return true;
-	}
-
-	return false;
-}
-
 /* Check whether page is a SpGist meta page */
 static bool
 IsSpGistMetaPage(Page page)
@@ -976,6 +967,24 @@ FormatHeader(char *buffer, Page page, BlockNumber blkno, bool isToast)
 			}
 			headerBytes += sizeof(BTMetaPageData);
 		}
+		else if (IsGinMetaPage(page))
+		{
+			GinMetaPageData *gpMeta = GinPageGetMeta(buffer);
+			if (!isToast || verbose)
+			{
+				printf("%s GIN Meta Data:           Version (%u)\n",
+					indent, gpMeta->ginVersion);
+				printf("%s Pending list:            Head:    (%u)  Tail:    (%u)  Tail Free Size:    (%u)\n",
+						indent, gpMeta->head, gpMeta->tail, gpMeta->tailFreeSize);
+				printf("%s                          Num of Pending Pages:    (%u)  Num of Pending Heap Tuples:    (%ld)\n",
+						indent, gpMeta->nPendingPages, gpMeta->nPendingHeapTuples);
+				printf("%s Statistic for planner:   Num of Total Pages:    (%u)  Num of Entry Pages:    (%u)\n",
+						indent, gpMeta->nTotalPages, gpMeta->nEntryPages);
+				printf("%s                          Num of Data Pages:    (%u)  Num of Entries:    (%ld)\n\n",
+						indent, gpMeta->nDataPages, gpMeta->nEntries);
+			}
+			headerBytes += sizeof(GinMetaPageData);
+		}
 
 		/* Eye the contents of the header and alert the user to possible 
 		 * problems. */
@@ -1107,6 +1116,88 @@ decode_varbyte(unsigned char **ptr)
 	return val;
 }
 
+static ItemPointer
+ginPostingListDecodeAllSegmentsItems(GinPostingList *segment, int len, int *ndecoded_out)
+{
+	ItemPointer result;
+	int			nallocated;
+	uint64		val;
+	char	   *endseg = ((char *) segment) + len;
+	int			ndecoded;
+	unsigned char *ptr;
+	unsigned char *endptr;
+
+	/*
+	 * Guess an initial size of the array.
+	 */
+	nallocated = segment->nbytes * 2 + 1;
+	result = palloc(nallocated * sizeof(ItemPointerData));
+
+	ndecoded = 0;
+	while ((char *) segment < endseg)
+	{
+		/* enlarge output array if needed */
+		if (ndecoded >= nallocated)
+		{
+			nallocated *= 2;
+			result = repalloc(result, nallocated * sizeof(ItemPointerData));
+		}
+
+		/* copy the first item */
+		result[ndecoded] = segment->first;
+		ndecoded++;
+
+		val = itemptr_to_uint64(&segment->first);
+		ptr = segment->bytes;
+		endptr = segment->bytes + segment->nbytes;
+		while (ptr < endptr)
+		{
+			/* enlarge output array if needed */
+			if (ndecoded >= nallocated)
+			{
+				nallocated *= 2;
+				result = repalloc(result, nallocated * sizeof(ItemPointerData));
+			}
+
+			val += decode_varbyte(&ptr);
+
+			uint64_to_itemptr(val, &result[ndecoded]);
+			ndecoded++;
+		}
+		segment = GinNextPostingListSegment(segment);
+	}
+
+	if (ndecoded_out)
+		*ndecoded_out = ndecoded;
+	return result;
+}
+
+static ItemPointer
+ginReadTupleItems(IndexTuple itup, int *nitems)
+{
+	Pointer		ptr = GinGetPosting(itup);
+	int			nipd = GinGetNPosting(itup);
+	ItemPointer ipd;
+	if (GinItupIsCompressed(itup))
+	{
+		if (nipd > 0)
+		{
+			ipd = ginPostingListDecodeAllSegmentsItems((GinPostingList *)ptr, SizeOfGinPostingList((GinPostingList *)ptr), nitems);
+		}
+		else
+		{
+			ipd = palloc(0);
+		}
+	}
+	else
+	{
+		ipd = (ItemPointer) palloc(sizeof(ItemPointerData) * nipd);
+		memcpy(ipd, ptr, sizeof(ItemPointerData) * nipd);
+	}
+	*nitems = nipd;
+	return ipd;
+}
+
 /*	Dump out gin-specific content of block */
 static void
 FormatGinBlock(char *buffer,
@@ -1122,10 +1213,17 @@ FormatGinBlock(char *buffer,
 	if (isToast && !verbose)
 		return;
 
+	if (GinPageIsDeleted(page))
+	{
+		printf("%s  Deleted page.\n\n", indent);
+		return;
+	}
+
 	printf("%s<Data> -----\n", indent);
 
-	if (IsGinLeafPage(page))
+	if (GinPageIsData(page) && GinPageIsLeaf(page))
 	{
+		printf("\n%s Leaf Page of TID B-tree\n",indent);
 		if (GinPageIsCompressed(page))
 		{
 			GinPostingList *seg = GinDataLeafPageGetPostingList(page);
@@ -1133,7 +1231,6 @@ FormatGinBlock(char *buffer,
 			Size			len = GinDataLeafPageGetPostingListSize(page);
 			Pointer			endptr = ((Pointer) seg) + len;
 			ItemPointer		cur;
-
 			while ((Pointer) seg < endptr)
 			{
 				int				item_idx = 1;
@@ -1186,23 +1283,97 @@ FormatGinBlock(char *buffer,
 			}
 		}
 	}
-	else
+	else if (!GinPageIsData(page) && GinPageIsLeaf(page))
+	{
+		printf("\n%s Leaf Page of Element B-tree", indent);
+		for (int offset = FirstOffsetNumber; offset <= PageGetMaxOffsetNumber(page); offset++)
+		{
+			IndexTuple itup;
+			itup = (IndexTuple) PageGetItem(page, PageGetItemId(page, offset));
+			if (!GinIsPostingTree(itup))
+			{
+				int nitems;
+				ItemPointer items = ginReadTupleItems(itup, &nitems);
+				printf("\n%s Posting List	%3d -- Length: %4u -- isCompressed: %d\n",
+					indent, offset, nitems, GinItupIsCompressed(itup));
+				for (int i = 0; i < nitems; i++)
+				{
+					printf("%s ItemPointer %d -- Block Id: %u linp Index: %u\n",
+							indent, i + 1,
+							((uint32) ((items[i].ip_blkid.bi_hi << 16) |
+									(uint16) items[i].ip_blkid.bi_lo)),
+							items[i].ip_posid);
+				}
+				pfree(items);
+			} else
+			{
+				BlockNumber rootPostingTree = GinGetPostingTree(itup);
+				printf("\n%s Root posting tree -- Block Id: %u\n",
+					indent, rootPostingTree);
+			}
+		}
+	}
+	else if (!GinPageIsLeaf(page) && GinPageIsData(page))
 	{
 		OffsetNumber	cur,
-						high = GinPageGetOpaque(page)->maxoff;
+						high = GinPageGetOpaque(page)->maxoff; /* number of PostingItems on GIN_DATA & ~GIN_LEAF page.*/
 		PostingItem	   *pitem = NULL;
 
+		ItemPointer rightBound = GinDataPageGetRightBound(page);
+
+		printf("%s Internal Page of TID B-tree -- Block Id: %u linp Index: %u\n",
+			indent,
+					((uint32) ((rightBound->ip_blkid.bi_hi << 16) |
+								(uint16) rightBound->ip_blkid.bi_lo)),
+					rightBound->ip_posid);
 		for (cur = FirstOffsetNumber; cur <= high; cur = OffsetNumberNext(cur))
 		{
 			pitem = GinDataPageGetPostingItem(page, cur);
-			printf("%s PostingItem %d -- child Block Id: (%u) Block Id: %u linp Index: %u\n",
+			printf("%s PostingItem %d -- child Block Id: (%u) Key Block Id: %u Key linp Index: %u\n",
 				   indent, cur,
-				   ((uint32) ((pitem->child_blkno.bi_hi << 16) |
-							  (uint16) pitem->child_blkno.bi_lo)),
-				   ((uint32) ((pitem->key.ip_blkid.bi_hi << 16) |
-							  (uint16) pitem->key.ip_blkid.bi_lo)),
-				   pitem->key.ip_posid);
+					((uint32) ((pitem->child_blkno.bi_hi << 16) |
+								(uint16) pitem->child_blkno.bi_lo)),
+					((uint32) ((pitem->key.ip_blkid.bi_hi << 16) |
+								(uint16) pitem->key.ip_blkid.bi_lo)),
+					pitem->key.ip_posid);
 		}
+	}
+	else if (GinPageIsList(page))
+	{
+		printf("\n%s Pending List Page	-- Length: %4u\n", indent, GinPageGetOpaque(page)->maxoff);
+		//Fast list index page, not compressed
+		for (OffsetNumber offset = FirstOffsetNumber; offset <= GinPageGetOpaque(page)->maxoff; offset = OffsetNumberNext(offset))
+		{
+			IndexTuple itup;
+			itup = (IndexTuple) PageGetItem(page, PageGetItemId(page, offset));
+			printf("%s ItemPointer -- Block Id: %u linp Index: %u\n",
+					indent,
+					((uint32) ((itup->t_tid.ip_blkid.bi_hi << 16) |
+						(uint16) itup->t_tid.ip_blkid.bi_lo)),
+					itup->t_tid.ip_posid);
+		}
+	}
+	else if (GinPageGetOpaque(page)->flags == 0)
+	{
+		/*details postgrespro/src/backend/access/gin/ginentrypage::GinFormInteriorTuple,
+		 *the specified child block number is inserted into t_tid.
+		 */
+		printf("\n%s Internal Page of Element B-tree \n", indent);
+		for (OffsetNumber offset = FirstOffsetNumber; offset <= PageGetMaxOffsetNumber(page); offset = OffsetNumberNext(offset))
+		{
+			IndexTuple itup;
+			itup = (IndexTuple) PageGetItem(page, PageGetItemId(page, offset));
+			printf("%s ItemPointer -- Block Id: %u linp Index: %u\n",
+					indent,
+					((uint32) ((itup->t_tid.ip_blkid.bi_hi << 16) |
+						(uint16) itup->t_tid.ip_blkid.bi_lo)),
+					itup->t_tid.ip_posid);
+		}
+	}
+	else
+	{
+		printf("%s  Error: Unknown page type.\n", indent);
+		exitCode = 1;
 	}
 
 	printf("\n");

--- a/run_test.sql
+++ b/run_test.sql
@@ -9,7 +9,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \lo_export :oid :output
 
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 --
 ----------------------------------------------------------------------------------------------

--- a/sql/datatypes.sql
+++ b/sql/datatypes.sql
@@ -10,7 +10,7 @@ insert into "int,text" values (1, 'one'), (null, 'two'), (3, null), (4, 'four');
 \ir run_test.sql
 
 -- do one test without options
-\! pg_filedump int,text.heap | sed -e 's/logid      ./logid      ./' -e 's/recoff 0x......../recoff 0x......../'
+\! pg_filedump int,text.heap | sed -e 's/logid      ./logid      ./' -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
 
 ----------------------------------------------------------------------------------------------
 

--- a/sql/toast.sql
+++ b/sql/toast.sql
@@ -34,5 +34,5 @@ select lo_import(format('base/%s/%s', :'datoid', :'reltoastrelid')) as toast_loi
 \lo_export :toast_loid :output
 
 \setenv relname :relname
-\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/"
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../; s/Checksum: 0x..../Checksum: 0x0000/" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'


### PR DESCRIPTION
Test details:
Postgres
commit 91f20bc2f7e4fcf5de5c65a6cb1190e0afa91c0b (HEAD, tag: REL_17_1)
pg_filedump
commit 7e26baf3725a9f2ed6ce9d312178c1137fcac431 (tag: REL_17_1)

t/001_basic.pl execution is successful, but if we comment  https://github.com/df7cb/pg_filedump/blob/7e26baf3725a9f2ed6ce9d312178c1137fcac431/t/001_basic.pl#L33C1-L33C21(test_btree_output),
test will fail with error:

> t/001_basic.pl .. 1/? 
>    Failed test 'Item found'
>    at t/001_basic.pl line 129.
>  Looks like you failed 1 test of 16.
> t/001_basic.pl .. Dubious, test returned 1 (wstat 256, 0x100)
> Failed 1/16 subtests
> 

If we run test for https://github.com/df7cb/pg_filedump/blob/7e26baf3725a9f2ed6ce9d312178c1137fcac431/t/001_basic.pl#L116 manually,
we will get empty Data section without any item pointers details for block 1.

```
*******************************************************************
* PostgreSQL File/Block Formatted Dump Utility
*
* File: data/base/5/16829
* Options used: -tvx
*******************************************************************

Block    0 ********************************************************
<Header> -----
 Block Offset: 0x00000000         Offsets: Lower      80 (0x0050)
 Block: Size 8192  Version    4            Upper    8184 (0x1ff8)
 LSN:  logid      0 recoff 0x01608350      Special  8184 (0x1ff8)
 Items:   14                      Free Space: 8104
 Checksum: 0x0000  Prune XID: 0x00000000  Flags: 0x0000 ()
 Length (including item array): 80

<Special Section> -----
 GIN Index Section:
  Flags: 0x00000008 (META)  Maxoff: 0
  Blocks: RightLink (-1)


Block    1 ********************************************************
<Header> -----
 Block Offset: 0x00002000         Offsets: Lower      36 (0x0024)
 Block: Size 8192  Version    4            Upper    8104 (0x1fa8)
 LSN:  logid      0 recoff 0x01608350      Special  8184 (0x1ff8)
 Items:    3                      Free Space: 8068
 Checksum: 0x0000  Prune XID: 0x00000000  Flags: 0x0000 ()
 Length (including item array): 36

<Data> -----

<Special Section> -----
 GIN Index Section:
  Flags: 0x00000002 (LEAF)  Maxoff: 0
  Blocks: RightLink (-1)


*** End of File Encountered. Last Block Read: 1 ***
```

As a resume, we have 2 problems:
1. Test runs t/001_basic.pl aren't isolated from each other
2. We lost data section details in GIN index dump and it seems it has never worked.

So, attached pull request fix:

1. t/001_basic.pl test runs isolation
2. Extend asserts for GIN test in t/001_basic.pl.
3. Fix the problem with Data section loss(it seems we have some skipped conditions), refactor GIN FormatGinBlock method, now we have clear if/else logic for all page types and appropriate processing algorithms.
4. No need process DELETED pages.
5. Add support of Pending list pages
6. Info was extended for META page
7. Fix problem with mask values with 'sed' in TAP tests.