### PR TITLE
Fix masking changing values in tests for LSN.

### DIFF
--- a/expected/datatypes.out
+++ b/expected/datatypes.out
@@ -14,7 +14,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -48,7 +48,7 @@ COPY: 4	four
 ----------------------------------------------------------------------------------------------
 --
 -- do one test without options
-\! pg_filedump int,text.heap | sed -e 's/logid      ./logid      ./' -e 's/recoff 0x......../recoff 0x......../'
+\! pg_filedump int,text.heap | sed -e 's/logid \+[0-9]\{1,6\}/logid      ./' -e 's/recoff 0x......../recoff 0x......../'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -88,7 +88,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -134,7 +134,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -178,7 +178,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -220,7 +220,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -264,7 +264,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -316,7 +316,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -362,7 +362,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -410,7 +410,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -452,7 +452,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -496,7 +496,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -542,7 +542,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -588,7 +588,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -630,7 +630,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -676,7 +676,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -725,7 +725,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -773,7 +773,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -821,7 +821,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -865,7 +865,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -909,7 +909,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -953,7 +953,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/datatypes_3.out
+++ b/expected/datatypes_3.out
@@ -14,7 +14,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -48,7 +48,7 @@ COPY: 4	four
 ----------------------------------------------------------------------------------------------
 --
 -- do one test without options
-\! pg_filedump int,text.heap | sed -e 's/logid      ./logid      ./' -e 's/recoff 0x......../recoff 0x......../'
+\! pg_filedump int,text.heap | sed -e 's/logid \+[0-9]\{1,6\}/logid      ./' -e 's/recoff 0x......../recoff 0x......../'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -88,7 +88,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -134,7 +134,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -178,7 +178,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -220,7 +220,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -264,7 +264,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -316,7 +316,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -362,7 +362,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -410,7 +410,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -452,7 +452,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -496,7 +496,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -542,7 +542,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -588,7 +588,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -630,7 +630,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -676,7 +676,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -725,7 +725,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -773,7 +773,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -821,7 +821,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -865,7 +865,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -909,7 +909,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -953,7 +953,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/float.out
+++ b/expected/float.out
@@ -15,7 +15,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -65,7 +65,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/float_1.out
+++ b/expected/float_1.out
@@ -15,7 +15,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -65,7 +65,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/float_3.out
+++ b/expected/float_3.out
@@ -15,7 +15,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -65,7 +65,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/float_4.out
+++ b/expected/float_4.out
@@ -15,7 +15,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -65,7 +65,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/numeric.out
+++ b/expected/numeric.out
@@ -16,7 +16,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/numeric_1.out
+++ b/expected/numeric_1.out
@@ -19,7 +19,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/numeric_3.out
+++ b/expected/numeric_3.out
@@ -16,7 +16,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/numeric_4.out
+++ b/expected/numeric_4.out
@@ -19,7 +19,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/toast.out
+++ b/expected/toast.out
@@ -26,7 +26,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'reltoastrelid')) as toast_loi
 \set output :reltoastrelid
 \lo_export :toast_loid :output
 \setenv relname :relname
-\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D text,text $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -62,7 +62,7 @@ COPY: extended compressed lz4	(TOASTED,lz4)
 
 
 *** End of File Encountered. Last Block Read: 0 ***
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/toast_1.out
+++ b/expected/toast_1.out
@@ -29,7 +29,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'reltoastrelid')) as toast_loi
 \set output :reltoastrelid
 \lo_export :toast_loid :output
 \setenv relname :relname
-\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D text,text $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -65,7 +65,7 @@ COPY: extended compressed lz4	(TOASTED,pglz)
 
 
 *** End of File Encountered. Last Block Read: 0 ***
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/toast_3.out
+++ b/expected/toast_3.out
@@ -26,7 +26,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'reltoastrelid')) as toast_loi
 \set output :reltoastrelid
 \lo_export :toast_loid :output
 \setenv relname :relname
-\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D text,text $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -62,7 +62,7 @@ COPY: extended compressed lz4	(TOASTED,lz4)
 
 
 *** End of File Encountered. Last Block Read: 0 ***
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/toast_4.out
+++ b/expected/toast_4.out
@@ -29,7 +29,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'reltoastrelid')) as toast_loi
 \set output :reltoastrelid
 \lo_export :toast_loid :output
 \setenv relname :relname
-\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D text,text $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility
@@ -65,7 +65,7 @@ COPY: extended compressed lz4	(TOASTED,pglz)
 
 
 *** End of File Encountered. Last Block Read: 0 ***
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/xml.out
+++ b/expected/xml.out
@@ -15,7 +15,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/xml_1.out
+++ b/expected/xml_1.out
@@ -20,7 +20,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/expected/xml_3.out
+++ b/expected/xml_3.out
@@ -15,7 +15,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \set output :relname '.heap'
 \lo_export :oid :output
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 *******************************************************************
 * PostgreSQL File/Block Formatted Dump Utility

--- a/run_test.sql
+++ b/run_test.sql
@@ -9,7 +9,7 @@ select lo_import(format('base/%s/%s', :'datoid', :'relfilenode')) as oid \gset
 \lo_export :oid :output
 
 \setenv relname :relname
-\! pg_filedump -D $relname $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D $relname $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
 
 --
 ----------------------------------------------------------------------------------------------

--- a/sql/datatypes.sql
+++ b/sql/datatypes.sql
@@ -10,7 +10,7 @@ insert into "int,text" values (1, 'one'), (null, 'two'), (3, null), (4, 'four');
 \ir run_test.sql
 
 -- do one test without options
-\! pg_filedump int,text.heap | sed -e 's/logid      ./logid      ./' -e 's/recoff 0x......../recoff 0x......../'
+\! pg_filedump int,text.heap | sed -e 's/logid \+[0-9]\{1,6\}/logid      ./' -e 's/recoff 0x......../recoff 0x......../'
 
 ----------------------------------------------------------------------------------------------
 

--- a/sql/toast.sql
+++ b/sql/toast.sql
@@ -34,5 +34,5 @@ select lo_import(format('base/%s/%s', :'datoid', :'reltoastrelid')) as toast_loi
 \lo_export :toast_loid :output
 
 \setenv relname :relname
-\! pg_filedump -D text,text $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../"
-\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid      ./logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'
+\! pg_filedump -D text,text $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../"
+\! pg_filedump -D text,text -t $relname.heap | sed -e "s/logid \+[0-9]\{1,6\}/logid      ./" -e "s/recoff 0x......../recoff 0x......../" -e 's/id:  ...../id:  ...../g' -e 's/ 8< .*//'


### PR DESCRIPTION
After running make installcheck for postgres with long live data, found that some tests can fail because expected files compare output with one digit logid.
But LSN can be more then one digit and in such cases tests asserts fails.

Applied patch fix it.